### PR TITLE
Adding command line support for specifying the output HTML file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <version>${batik.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.0.29</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/nl/bigo/rrdantlr4/Main.java
+++ b/src/main/java/nl/bigo/rrdantlr4/Main.java
@@ -1,5 +1,11 @@
 package nl.bigo.rrdantlr4;
 
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 /**
  * A class containing a main method used in the packaged JAR file to
  * parse a grammar provided from the command line.
@@ -18,12 +24,23 @@ public class Main {
      */
     public static void main(String[] args) throws Exception {
 
-        if (args.length != 1) {
-            System.err.println("usage: java -jar rrd-antlr4-0.1.0.jar GRAMMAR_FILE");
+        RrdAntlrOptions rrdAntlrOptions = new RrdAntlrOptions();
+        final CmdLineParser cmdLineParser = new CmdLineParser(rrdAntlrOptions);
+
+        try {
+            cmdLineParser.parseArgument(args);
+        } catch (CmdLineException e) {
+            System.err.println(e.getMessage());
+            printUsage(cmdLineParser, System.err);
             System.exit(1);
         }
 
-        String fileName = args[0];
+        if (rrdAntlrOptions.isRequestingHelp()) {
+            printUsage(cmdLineParser, System.out);
+            System.exit(0);
+        }
+
+        String fileName = rrdAntlrOptions.getInputFileName();
 
         System.out.println("parsing: " + fileName + " ...");
 
@@ -37,8 +54,13 @@ public class Main {
 
         System.out.println("creating an html page of the grammar...");
 
-        generator.createHtml();
+        generator.createHtml(rrdAntlrOptions.getOutputFileName());
 
         System.out.println("finished");
+    }
+
+    private static void printUsage(CmdLineParser cmdLineParser, PrintStream out) {
+        out.println("usage: java -jar rrd-antlr4-0.1.0.jar [options] GRAMMAR_FILE");
+        cmdLineParser.printUsage(out);
     }
 }

--- a/src/main/java/nl/bigo/rrdantlr4/RrdAntlrOptions.java
+++ b/src/main/java/nl/bigo/rrdantlr4/RrdAntlrOptions.java
@@ -1,0 +1,31 @@
+package nl.bigo.rrdantlr4;
+
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
+
+/**
+ * Declares the command line options accepted by the main application.
+ */
+public class RrdAntlrOptions {
+    @Argument(required = true, metaVar = "GRAMMAR_FILE", usage = "An ANTLR4 grammar file to process")
+    private String inputFileName;
+
+    @Option(name="--out", metaVar = "HTML_FILE", usage = "The HTML file where the resulting diagrams are generated." +
+            "\nDefault is index.html")
+    private String outputFileName = "index.html";
+
+    @Option(name="--help", aliases = {"-?","-h"}, help = true, usage = "Show the command line usage and exit")
+    private boolean requestingHelp;
+
+    public String getInputFileName() {
+        return inputFileName;
+    }
+
+    public String getOutputFileName() {
+        return outputFileName;
+    }
+
+    public boolean isRequestingHelp() {
+        return requestingHelp;
+    }
+}


### PR DESCRIPTION
I have been running a post-processing sed to rename the index.html file and the <a>'s within; however, I just noticed your code already allowed for alternate naming of the HTML file. There just wasn't a command line option for it yet.

While I was at it I added my favorite command line processor: arg4j.