### PR TITLE
Parse comments from the g4 file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,27 @@
             <version>${itextpdf.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
 
     <build>
-
         <plugins>
-
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>

--- a/src/main/antlr4/nl/bigo/rrdantlr4/ANTLRv4Parser.g4
+++ b/src/main/antlr4/nl/bigo/rrdantlr4/ANTLRv4Parser.g4
@@ -36,7 +36,7 @@ options {
 	tokenVocab=ANTLRv4Lexer;
 }
 
-// The main entry point for parsing a v4 grammar.
+/* <grammarSpec> The main entry point for parsing a v4 grammar. */
 grammarSpec
 	:	DOC_COMMENT?
 		grammarType id SEMI
@@ -53,10 +53,13 @@ grammarType
 		)
 	;
 
-// This is the list of all constructs that can be declared before
-// the set of rules that compose the grammar, and is invoked 0..n
-// times by the grammarPrequel rule.
+/* <prequelConstruct>
+** This is the list of all constructs that can be declared before
+** the set of rules that compose the grammar, and is invoked 0..n
+** times by the grammarPrequel rule.
+*/
 prequelConstruct
+
 	:	optionsSpec
 	|	delegateGrammars
 	|	tokensSpec

--- a/src/main/java/nl/bigo/rrdantlr4/CommentsParser.java
+++ b/src/main/java/nl/bigo/rrdantlr4/CommentsParser.java
@@ -1,0 +1,58 @@
+package nl.bigo.rrdantlr4;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommentsParser {
+    public static final String RULE_NAME_PATTERN = "<(.*?)>";
+    public static final String COMMENT_BOUNDARY_PATTERN = "/\\*|\\*/";
+
+    public static Optional<String> ruleName(String comment) {
+        Matcher matcher = patternMatcher(comment, RULE_NAME_PATTERN);
+
+        if (matcher.find()) {
+            return Optional.of(matcher.group(1));
+        }
+        return Optional.absent();
+    }
+
+    public static String ruleDescription(String comment) {
+        return comment.replaceAll(RULE_NAME_PATTERN, "").replaceAll(COMMENT_BOUNDARY_PATTERN, "").trim();
+    }
+
+    public static List<String> comments(String input) {
+        List<String> comments = Lists.newArrayList();
+
+        Matcher commentMatcher = patternMatcher(input, "/\\*(.)*?\\*/");
+
+        while (commentMatcher.find()) {
+            comments.add(commentMatcher.group());
+
+        }
+        return comments;
+    }
+
+    public static Map<String, String> commentsMap(String input) {
+        HashMap<String, String> commentsMap = Maps.newHashMap();
+        List<String> comments = comments(input);
+        for (String comment : comments) {
+            Optional<String> ruleName = ruleName(comment);
+            if (ruleName.isPresent()) {
+                commentsMap.put(ruleName.get(), ruleDescription(comment));
+            }
+        }
+        return commentsMap;
+    }
+
+    private static Matcher patternMatcher(String input, String regex) {
+        Pattern commentsPattern = Pattern.compile(regex,Pattern.MULTILINE | Pattern.DOTALL);
+        return commentsPattern.matcher(input);
+    }
+}

--- a/src/main/resources/template.css
+++ b/src/main/resources/template.css
@@ -5,3 +5,7 @@ body {
 h1 {
     padding-bottom: 10px;
 }
+
+.border-notop td{
+ border-top: none;
+ }

--- a/src/test/java/CommentsParserTest.java
+++ b/src/test/java/CommentsParserTest.java
@@ -1,0 +1,67 @@
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static nl.bigo.rrdantlr4.CommentsParser.*;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class CommentsParserTest {
+    public static final String RULE_ONE = "/* <RULE_NAME> RULE_DESCRIPTION*/";
+    public static final String RULE_TWO = "/* <RULE2_NAME> RULE2_DESCRIPTION*/";
+
+    @Test
+    public void it_should_find_the_rule_name_of_a_comment() {
+        Optional<String> ruleName = ruleName(RULE_ONE);
+        assertThat(ruleName).isEqualTo(Optional.of("RULE_NAME"));
+    }
+
+    @Test
+    public void it_should_return_an_absent_string_when_the_rule_name_is_missing() {
+        Optional<String> ruleName = ruleName("/*RULE_DESCRIPTION*/");
+        assertThat(ruleName).isEqualTo(Optional.<String>absent());
+    }
+
+    @Test
+    public void it_should_find_the_rule_description_of_a_comment() {
+        String ruleName = ruleDescription(RULE_ONE);
+        assertThat(ruleName).isEqualTo("RULE_DESCRIPTION");
+    }
+
+    @Test
+    public void it_should_find_the_comments_from_a_string_input() {
+        List<String> comments = comments(RULE_ONE + " HELLO " + RULE_TWO);
+        assertThat(comments).containsOnly(RULE_ONE, RULE_TWO);
+    }
+
+    @Test
+    public void it_should_return_an_empty_list_when_no_comment_pattern_is_found() {
+        List<String> comments = comments(" HELLO ");
+        assertThat(comments).isEmpty();
+    }
+
+    @Test
+    public void it_should_return_a_map_of_rule_name_to_description() {
+        Map<String, String> ruleNameToDescription = commentsMap(RULE_ONE + " HELLO " + RULE_TWO);
+        assertThat(ruleNameToDescription).isEqualTo(ImmutableMap.of("RULE_NAME", "RULE_DESCRIPTION", "RULE2_NAME", "RULE2_DESCRIPTION"));
+    }
+
+    @Test
+    public void it_should_ignore_comments_without_rule_names() {
+        Map<String, String> ruleNameToDescription = commentsMap(RULE_ONE + " HELLO /*RULE_DESCRIPTION*/");
+        assertThat(ruleNameToDescription).isEqualTo(ImmutableMap.of("RULE_NAME", "RULE_DESCRIPTION"));
+    }
+
+    @Test
+    public void it_should_parse_a_text_with_new_lines() {
+        Map<String, String> ruleNameToDescription = commentsMap("/*"
+
+            + "<RULE_NAME> RULE_DESCRIPTION \n"
+
+            + "*/");
+        assertThat(ruleNameToDescription).isEqualTo(ImmutableMap.of("RULE_NAME", "RULE_DESCRIPTION"));
+    }
+
+}


### PR DESCRIPTION
- Parse the comments for each rule in the g4 file
- Comments should follow a standard pattern:   `/*<RULE_NAME> RULE
DESCRIPTION*/`
- Comments with that pattern will be added to the html file under the
respective rule section