### PR TITLE
add charset to template.html

### DIFF
--- a/src/main/resources/template.html
+++ b/src/main/resources/template.html
@@ -3,6 +3,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+    <meta charset="UTF-8">
     <title>${grammar}</title>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>


### PR DESCRIPTION
more extensive language support

when viewed in a browser, some lexer rules containing non-latin characters were not being displayed correctly, now the generated index.html can instruct the browser to support a richer set of characters