### PR TITLE
update to work with later versions of maven and modify example for new URL and method for fetching it

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ repository, run the following command from the terminal:
 
 ```
 cd target
-java -jar rrd-antlr4-0.1.2.jar https://raw.github.com/antlr/grammars-v4/master/json/Json.g4
+curl -O https://raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4
+java -jar rrd-antlr4-0.1.2.jar JSON.g4
 ```
 
-When the command above finishes, one html file and some png images
-will have been generated in the folder `./output/Json`. The html file
+When the command above finishes, one html and pdf file and some png images
+will have been generated in the folder `./output/JSON`. The html file
 does not make use of the png files but uses SVG to display the railroad
 diagram and will look like this:
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <args4j.version>2.0.29</args4j.version>
         <itextpdf.version>5.5.6</itextpdf.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Was getting following compile error with mvn

```
mvn --version     
Apache Maven 3.5.2
Maven home: /usr/share/maven
Java version: 10.0.2, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-11-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-42-generic", arch: "amd64", family: "unix"
```

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.647 s
[INFO] Finished at: 2018-12-11T15:57:22-08:00
[INFO] Final Memory: 14M/60M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project rrd-antlr4: Compilation failure: Compilation failure: 
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

Also the URL for json example changed and I was getting following error when I tried to use the updated URL.  I chose to update README.md with what worked for me instead of debugging this further.

```
java -jar rrd-antlr4-0.1.2.jar https://raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4

parsing: https://raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4 ...
Exception in thread "main" java.io.FileNotFoundException: https:/raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4 (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:220)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:158)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:113)
        at nl.bigo.rrdantlr4.DiagramGenerator.<init>(DiagramGenerator.java:99)
        at nl.bigo.rrdantlr4.Main.main(Main.java:46)
```

curl works with same URL:
```
curl -O https://raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4                       
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   850  100   850    0     0   4146      0 --:--:-- --:--:-- --:--:--  4146

```